### PR TITLE
Rework ping command

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -233,6 +233,9 @@ export abstract class Command
         {
             const noPerm = () => int.reply({ embeds: [ embedify("You don't have permission to run this command.", settings.embedColors.error) ], ephemeral: true });
 
+            if(this.meta.devOnly === true && !Array.isArray(settings.devs))
+                throw new Error("Environment variables not set up correctly");
+
             if(this.meta.devOnly === true && !settings.devs.includes(int.user.id))
                 return await noPerm();
 

--- a/src/commands/Template.ts
+++ b/src/commands/Template.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, ApplicationCommandOptionType } from "discord.js";
 import { Command } from "@src/Command";
 
 export class TEMPLATE extends Command
@@ -9,7 +9,14 @@ export class TEMPLATE extends Command
             name: "template_name",
             desc: "Template_desc",
             category: "util",
-            perms: [],
+            args: [
+                {
+                    name: "example_arg",
+                    desc: "Example argument",
+                    type: ApplicationCommandOptionType.String,
+                },
+            ],
+            memberPerms: [],
         });
     }
 

--- a/src/commands/fun/Mock.ts
+++ b/src/commands/fun/Mock.ts
@@ -41,10 +41,8 @@ export class Mock extends Command
         if(ephemeral)
             return await this.reply(int, mockified, ephemeral);
 
-        await this.reply(int, "Sending message...", true);
-
         await channel.send(`<:mock:506303207400669204> ${mockified}`);
 
-        return await int.deleteReply();
+        await this.reply(int, "Sent the message.", true);
     }
 }

--- a/src/commands/util/Ping.ts
+++ b/src/commands/util/Ping.ts
@@ -142,7 +142,7 @@ export class Ping extends Command {
             const res = /.*max-age=(\d+).*/i.exec(hstsHeader);
             const [, hstsValRaw] = res ?? [undefined, undefined];
             const hstsVal = parseInt(String(hstsValRaw));
-            const hstsLabel = (!isNaN(hstsVal) && hstsVal >= 63072000) ? "🔒 Enhanced (preloaded)" : (hstsEnabled ? "🔒 Yes" : "🔓 No");
+            const hstsLabel = (!isNaN(hstsVal) && hstsVal >= 31536000) ? "🔒 Enhanced (preloaded)" : (hstsEnabled ? "🔒 Yes" : "🔓 No");
 
             const fields: EmbedField[] = [
                 {

--- a/src/commands/util/Ping.ts
+++ b/src/commands/util/Ping.ts
@@ -1,17 +1,226 @@
-import { CommandInteraction } from "discord.js";
+import { ApplicationCommandOptionType, Collection, CommandInteraction, EmbedBuilder, EmbedField } from "discord.js";
+import { isIP } from "net";
 import { Command } from "@src/Command";
+import { axios, embedify } from "@src/utils";
+import { settings } from "@src/settings";
+import { AxiosError } from "axios";
+
+interface MimeInfo {
+    exts: string[];
+    name: string;
+}
 
 export class Ping extends Command {
     constructor()
     {
         super({
             name: "ping",
-            desc: "Check if the bot is alive",
-            category: "util"
+            desc: "Visits a URL, follows redirects and gives you all kinds of information about it",
+            category: "util",
+            args: [
+                {
+                    name: "url",
+                    desc: "The URL to gather information about. Has to start with https:// or http://",
+                    type: ApplicationCommandOptionType.String,
+                    required: true,
+                },
+            ],
+            // TODO: implement proxy so we don't dox our IP lol
+            devOnly: true,
         });
     }
 
-    async run(int: CommandInteraction): Promise<void> {
-        await this.reply(int, "Pong!", true);
+    private readonly HOST_BLACKLIST = [ "localhost", "[::1]" ];
+    private readonly MIME_MAP = new Collection<string, MimeInfo>([
+        [ "audio/aac", { exts: [ ".aac" ], name: "AAC audio" }],
+        [ "image/avif", { exts: [ ".avif" ], name: "AVIF image" }],
+        [ "video/x-msvideo", { exts: [ ".avi" ], name: "AVI: Audio Video Interleave" }],
+        [ "application/octet-stream", { exts: [ ".bin" ], name: "Any kind of binary data" }],
+        [ "image/bmp", { exts: [ ".bmp" ], name: "Windows OS/2 Bitmap Graphics" }],
+        [ "text/css", { exts: [ ".css" ], name: "Cascading Style Sheets (CSS)" }],
+        [ "text/csv", { exts: [ ".csv" ], name: "Comma-separated values (CSV)" }],
+        [ "application/msword", { exts: [ ".doc" ], name: "Microsoft Word" }],
+        [ "application/vnd.openxmlformats-officedocument.wordprocessingml.document", { exts: [ ".docx" ], name: "Microsoft Word (OpenXML)" }],
+        [ "application/epub+zip", { exts: [ ".epub" ], name: "Electronic publication (EPUB)" }],
+        [ "application/gzip", { exts: [ ".gz" ], name: "GZip Compressed Archive" }],
+        [ "image/gif", { exts: [ ".gif" ], name: "Graphics Interchange Format (GIF)" }],
+        [ "text/html", { exts: [ ".htm", ".html" ], name: "HyperText Markup Language (HTML)" }],
+        [ "image/vnd.microsoft.icon", { exts: [ ".ico" ], name: "Microsoft icon format" }],
+        [ "text/calendar", { exts: [ ".ics" ], name: "iCalendar format" }],
+        [ "application/java-archive", { exts: [ ".jar" ], name: "Java Archive (JAR)" }],
+        [ "image/jpeg", { exts: [ ".jpeg", ".jpg" ], name: "JPEG image" }],
+        [ "text/javascript", { exts: [ ".js" ], name: "JavaScript" }],
+        [ "application/json", { exts: [ ".json" ], name: "JavaScript Object Notation (JSON)" }],
+        [ "text/javascript", { exts: [ ".mjs" ], name: "JavaScript module" }],
+        [ "audio/mpeg", { exts: [ ".mp3" ], name: "MP3 audio" }],
+        [ "video/mp4", { exts: [ ".mp4" ], name: "MP4 video" }],
+        [ "video/mpeg", { exts: [ ".mpeg" ], name: "MPEG video" }],
+        [ "application/vnd.oasis.opendocument.presentation", { exts: [ ".odp" ], name: "OpenDocument presentation" }],
+        [ "application/vnd.oasis.opendocument.spreadsheet", { exts: [ ".ods" ], name: "OpenDocument spreadsheet" }],
+        [ "application/vnd.oasis.opendocument.text", { exts: [ ".odt" ], name: "OpenDocument text document" }],
+        [ "audio/ogg", { exts: [ ".ogg", ".oga" ], name: "OGG audio" }],
+        [ "application/ogg", { exts: [ ".ogg", ".ogx" ], name: "OGG" }],
+        [ "video/ogg", { exts: [ ".ogv" ], name: "OGG video" }],
+        [ "audio/opus", { exts: [ ".opus" ], name: "Opus audio" }],
+        [ "font/otf", { exts: [ ".otf" ], name: "OpenType font" }],
+        [ "image/png", { exts: [ ".png" ], name: "Portable Network Graphics (PNG)" }],
+        [ "application/pdf", { exts: [ ".pdf" ], name: "Adobe Portable Document Format (PDF)" }],
+        [ "application/x-httpd-php", { exts: [ ".php" ], name: "Hypertext Preprocessor (PHP)" }],
+        [ "application/vnd.ms-powerpoint", { exts: [ ".ppt" ], name: "Microsoft PowerPoint" }],
+        [ "application/vnd.openxmlformats-officedocument.presentationml.presentation", { exts: [ ".pptx" ], name: "Microsoft PowerPoint (OpenXML)" }],
+        [ "application/vnd.rar", { exts: [ ".rar" ], name: "RAR archive" }],
+        [ "application/rtf", { exts: [ ".rtf" ], name: "Rich Text Format (RTF)" }],
+        [ "application/x-sh", { exts: [ ".sh" ], name: "Bourne shell script" }],
+        [ "image/svg+xml", { exts: [ ".svg" ], name: "Scalable Vector Graphics (SVG)" }],
+        [ "application/x-tar", { exts: [ ".tar" ], name: "Tape Archive (TAR)" }],
+        [ "image/tiff", { exts: [ ".tif", ".tiff" ], name: "Tagged Image File Format (TIFF)" }],
+        [ "font/ttf", { exts: [ ".ttf" ], name: "TrueType Font" }],
+        [ "text/plain", { exts: [ ".txt" ], name: "Plain Text" }],
+        [ "audio/wav", { exts: [ ".wav" ], name: "Waveform Audio Format" }],
+        [ "audio/webm", { exts: [ ".weba" ], name: "WEBM audio" }],
+        [ "video/webm", { exts: [ ".webm" ], name: "WEBM video" }],
+        [ "image/webp", { exts: [ ".webp" ], name: "WEBP image" }],
+        [ "font/woff", { exts: [ ".woff" ], name: "Web Open Font Format (WOFF)" }],
+        [ "font/woff2", { exts: [ ".woff2" ], name: "Web Open Font Format 2.0 (WOFF2)" }],
+        [ "application/xhtml+xml", { exts: [ ".xhtml" ], name: "XHTML" }],
+        [ "application/vnd.ms-excel", { exts: [ ".xls" ], name: "Microsoft Excel" }],
+        [ "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", { exts: [ ".xlsx" ], name: "Microsoft Excel (OpenXML)" }],
+        [ "application/xml", { exts: [ ".xml" ], name: "XML" }],
+        [ "text/xml", { exts: [ ".xml" ], name: "XML" }],
+        [ "application/zip", { exts: [ ".zip" ], name: "ZIP archive" }],
+        [ "video/3gpp", { exts: [ ".3gp" ], name: "3GPP video container" }],
+        [ "audio/3gpp", { exts: [ ".3gp" ], name: "3GPP audio container" }],
+        [ "application/x-7z-compressed", { exts: [ ".7z" ], name: "7-zip archive" }],
+    ]);
+
+    async run(int: CommandInteraction) {
+        const urlArg = (int.options.get("url", true).value as string).trim();
+
+        const url = this.parseUrl(urlArg);
+
+        const invalidUrl = () => this.reply(int, embedify("This URL is invalid. Please try again.", settings.embedColors.error), true);
+
+        if(!url)
+        {
+            if(!urlArg.match(/^https?/i))
+                return this.reply(int, embedify("Please make sure the URL starts with `https://` or `http://`", settings.embedColors.error), true);
+            return invalidUrl();
+        }
+
+        if(!(["http:", "https:"].includes(url.protocol)))
+            return this.reply(int, embedify("Protocols other than `https://` and `http://` aren't supported.", settings.embedColors.error), true);
+
+        if(this.HOST_BLACKLIST.includes(url.hostname))
+            return invalidUrl();
+
+        // TODO: implement check for local IP maybe (but this can easily be a dangerous vuln so maybe not)
+        // maybe instead give reduced information?
+        if(isIP(url.hostname.replace(/[[\]]/g, "")) > 0)
+            return this.reply(int, embedify("IP addresses can't be pinged yet.", settings.embedColors.error), true);
+
+        await this.deferReply(int);
+
+        try {
+            // wyd if wants GET HEAD but also VIEW the other OPTIONS and PUT thing inside her PATCH
+            // but next day there no TRACE of her, phone is UNLOCK and she POST ur nudes online and she DELETE ur number?
+            const { status, headers, statusText } = await axios.head(urlArg, {
+                // don't throw on 4xx and 5xx
+                validateStatus: () => true,
+                headers: {
+                    // lol maybe this helps
+                    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
+                },
+            });
+
+            const contentType = headers["content-type"];
+            const hstsHeader = headers["strict-transport-security"];
+
+            const mimeType = (contentType && contentType.includes(";") ? contentType.split(";")[0] : contentType)?.trim();
+            const mimeInfo = this.MIME_MAP.get(mimeType);
+
+            const hstsEnabled = hstsHeader?.toLowerCase().includes("max-age");
+            const res = /.*max-age=(\d+).*/i.exec(hstsHeader);
+            const [, hstsValRaw] = res ?? [undefined, undefined];
+            const hstsVal = parseInt(String(hstsValRaw));
+            const hstsLabel = (!isNaN(hstsVal) && hstsVal >= 63072000) ? "🔒 Enhanced (preloaded)" : (hstsEnabled ? "🔒 Yes" : "🔓 No");
+
+            const fields: EmbedField[] = [
+                {
+                    name: "URL",
+                    value: `[\`${urlArg}\`](${urlArg})`,
+                    inline: true,
+                },
+                {
+                    name: "Status",
+                    value: `${status}${statusText && statusText.length > 0 ? ` - ${statusText}` : ""}`,
+                    inline: true,
+                },
+                {
+                    name: "Security",
+                    value: [
+                        `[HTTPS:](https://en.wikipedia.org/wiki/HTTPS) ${url.protocol === "https:" ? "🔒 Yes" : "🔓 No"}`,
+                        `[HSTS:](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) ${hstsLabel}`,
+                    ].join("\n"),
+                    inline: true,
+                },
+            ];
+
+            mimeInfo && fields.push({
+                name: "Content Type",
+                value: `${mimeInfo.name}\nExtension${mimeInfo.exts.length === 1 ? "" : "s"}: ${mimeInfo.exts.reduce((a, c) => `${a.length > 0 ? `${a}, ` : ""}${c}`, "")}`,
+                inline: true,
+            });
+
+            const ebd = new EmbedBuilder()
+                .setTitle("URL information:")
+                .setColor(settings.embedColors.default)
+                .setFields(...fields);
+
+            return this.editReply(int, ebd);
+        }
+        catch(err) {
+            if(Ping.isAxiosError(err))
+            {
+                const ebd = new EmbedBuilder()
+                    .setTitle("URL Information:")
+                    .setFields([
+                        {
+                            name: "URL",
+                            value: `[\`${urlArg}\`](${urlArg})`,
+                            inline: true,
+                        },
+                        {
+                            name: "Status",
+                            value: err.status ? String(err.status) : "🛑 aborted",
+                            inline: true,
+                        },
+                        {
+                            name: "Security",
+                            value: "[HTTPS:](https://en.wikipedia.org/wiki/HTTPS) ⚠️ Certificate expired or invalid",
+                            inline: false,
+                        },
+                    ])
+                    .setColor(settings.embedColors.error);
+
+                return this.editReply(int, ebd);
+            }
+            return this.editReply(int, embedify("Encountered an internal error. Please try again later.", settings.embedColors.error));
+        }
+    }
+
+    static isAxiosError(val: unknown): val is AxiosError
+    {
+        return typeof val === "object" && (val as Record<string, unknown>)?.isAxiosError === true;
+    }
+
+    parseUrl(urlArg: string)
+    {
+        try {
+            const url = new URL(urlArg);
+            return url;
+        }
+        catch(e) {
+            return null;
+        }
     }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,6 +14,8 @@ import { initHelp } from "@commands/util/Help";
 import EventEmitter from "events";
 import { embedify } from "./utils";
 import { settings } from "./settings";
+import { unused } from "svcorelib";
+// import { PutGuildCommandResult } from "./types";
 
 
 const rest = new REST({ version: "10" })
@@ -113,11 +115,20 @@ export async function registerGuildCommands(...guildIDs: (string|string[])[]): P
     {
         // console.log(`Registering guild commands in ${client.guilds.cache.find(g => g.id === guild)?.name}`);
 
-        await rest.put(
+        const restRes = await rest.put(
             Routes.applicationGuildCommands(process.env.CLIENT_ID ?? "ERR_NO_ENV", guild), {
                 body: slashCmds
             },
         );
+
+        unused(restRes);
+
+        // #DEBUG use this to get a command's ID
+        // if(guild === "693878197107949572")
+        // {
+        //     const cmd = (restRes as Record<string, string>[]).find(cmd => cmd.name === "ferret") as undefined | PutGuildCommandResult;
+        //     console.log(cmd);
+        // }
     }
 }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -126,7 +126,7 @@ export async function registerGuildCommands(...guildIDs: (string|string[])[]): P
         // #DEBUG use this to get a command's ID
         // if(guild === "693878197107949572")
         // {
-        //     const cmd = (restRes as Record<string, string>[]).find(cmd => cmd.name === "ferret") as undefined | PutGuildCommandResult;
+        //     const cmd = (restRes as PutGuildCommandResult[])?.find(cmd => cmd.name === "ferret");
         //     console.log(cmd);
         // }
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export const settings: Settings = Object.freeze({
         /** Whether to send a bell sound in the console when the bot is ready */
         bellOnReady: envVarEquals("BELL_ON_READY", true),
     },
+    // TODO: this will be removed once these settings can be changed per guild
     moderation: {
         /** How many reaction votes are needed to ban someone */
         votesToBan: 2,
@@ -42,12 +43,12 @@ export const settings: Settings = Object.freeze({
         ],
     },
     embedColors: {
-        default: "#faba05",
-        success: Colors.Green,
-        gameLost: Colors.Grey,
-        warning: Colors.Orange,
-        error: Colors.DarkRed,
-        contestWinner: Colors.Gold,
+        default: getEnvVar("EMBED_COLOR_DEFAULT") ?? "#faba05",
+        success: getEnvVar("EMBED_COLOR_SUCCESS") ?? Colors.Green,
+        gameLost: getEnvVar("EMBED_COLOR_GAME_LOST") ?? Colors.Grey,
+        warning: getEnvVar("EMBED_COLOR_WARNING") ?? Colors.Orange,
+        error: getEnvVar("EMBED_COLOR_ERROR") ?? Colors.DarkRed,
+        contestWinner: getEnvVar("EMBED_COLOR_CONTEST_WINNER") ?? Colors.Gold,
     },
     /** Incremental list of emojis used in reactions */
     emojiList: [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯", "🇰", "🇱", "🇲", "🇳", "🇴", "🇵", "🇶", "🇷", "🇸", "🇹" ],
@@ -57,7 +58,7 @@ export const settings: Settings = Object.freeze({
     },
 }) as Settings;
 
-/** Tests if the environment variable `varName` equals `value` casted to string - value is case insensitive */
+/** Tests if the environment variable `varName` equals `value` casted to string - both params are case insensitive */
 function envVarEquals(varName: string, value: Stringifiable)
 {
     return process.env[varName]?.toLowerCase() === value.toString().toLowerCase();
@@ -92,7 +93,7 @@ export function getEnvVar<T extends ("string" | "number" | "stringArray" | "numb
         transform = v => v.trim().split(commasRegex);
         break;
     case "numberArray":
-        transform = v => v.trim().split(commasRegex).map(n => parseInt(n));
+        transform = v => v.split(commasRegex).map(n => parseInt(n.trim()));
         break;
     }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -93,6 +93,22 @@ export interface SubcommandMeta extends CmdMetaBase {
     subcommands: Omit<CommandMeta, "memberPerms" | "category">[];
 }
 
+/** Result of PUTing a guild command to the Discord API */
+export interface PutGuildCommandResult {
+    application_id: string;
+    default_member_permissions: null | string;
+    default_permission: boolean;
+    description_localizations: null;
+    description: string;
+    guild_id: string;
+    id: string;
+    name_localizations: null;
+    name: string;
+    options?: Record<string, unknown>[];
+    type: ApplicationCommandOptionType;
+    version: string;
+}
+
 //#SECTION reactionroles
 
 export interface ReactionRole {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,5 +1,6 @@
 import _axios from "axios";
 
+/** Default preconfigured axios instance */
 export const axios = _axios.create({
     timeout: 1000 * 15,
 });
@@ -9,6 +10,8 @@ export async function followRedirects(url: string): Promise<string | null>
 {
     try
     {
+        new URL(url);
+
         const { request } = await axios.get(url);
 
         return request?.res?.responseUrl ?? null;


### PR DESCRIPTION
The `/ping` command can now actually ping a URL and gather some info.  
The request is done with the HEAD method so no data is downloaded.  
IPs and localhost are disallowed to prevent vulns.  
The command is devOnly for now, until I host like a small proxy VPS so we don't doxx our IP.  
  
![grafik](https://user-images.githubusercontent.com/38158426/194176036-f356abc0-2189-474b-8ff4-3d887b4903f1.png)
